### PR TITLE
fix wrong case for secretName variable name

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,14 +49,18 @@ spec:
             value: {{ .Values.passbolt.config.email.host }}
           - name: EMAIL_TRANSPORT_DEFAULT_PORT
             value: {{ .Values.passbolt.config.email.port | quote }}
+          {{- if .Values.passbolt.config.email.tls }}
           - name: EMAIL_TRANSPORT_DEFAULT_TLS
             value: {{ .Values.passbolt.config.email.tls | quote }}
+          {{- end }}
           - name: EMAIL_TRANSPORT_DEFAULT_TIMEOUT
             value: {{ .Values.passbolt.config.email.timeout | quote }}
+          {{- if .Values.passbolt.config.email.username }}
           - name: EMAIL_TRANSPORT_DEFAULT_USERNAME
             value: {{ .Values.passbolt.config.email.username }}
           - name: EMAIL_TRANSPORT_DEFAULT_PASSWORD
             value: {{ .Values.passbolt.config.email.password }}
+          {{- end }}
           {{- end }}
           - name: PASSBOLT_REGISTRATION_PUBLIC
             value: {{ .Values.passbolt.config.registration | quote }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.host }}
-    secretName: {{ .Values.ingress.tls.SecretName }}
+    secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
   - host: {{ .Values.ingress.host }}


### PR DESCRIPTION
Variable referenced as "secretName" in values.yaml, but used as "SecretName" in ingress template