### PR TITLE
Draft: Update Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This helm chart installs the [passbolt container](https://github.com/passbolt/pa
 
 For more parameters you should have a look at ...
 - the [values.yaml](values.yaml) file of this helm chart
-- the [values.yaml](https://github.com/helm/charts/blob/master/stable/mariadb/values.yaml) file of the mariadb helm chart
+- the [values.yaml](https://github.com/helm/charts/blob/master/stable/mariadb/values.yaml) file of the mariadb helm chart, when enabled
 - the [enviroment variables](https://github.com/passbolt/passbolt_docker/tree/master) of the passbold docker image.
 
 ### General
@@ -43,6 +43,8 @@ For more parameters you should have a look at ...
 | `passbolt.config.gpgServerKeyFingerprint` | The GPG server key fingerprint. See [GPG key generation](#gpg-key-generation) | `"your gpg server key fingerprint"` |
 | `passbolt.config.serverkey` | The GPG server key. If set the key will not be read from [file](secrets/gpg/serverkey.asc) | ` ` |
 | `passbolt.config.serverkey_private` | The GPG private server key. If set the private key will not be read from [file](secrets/gpg/serverkey_private.asc) | ` ` |
+| `passbolt.config.jwtkey` | The GPG server key. If set the key will not be read from [file](secrets/gpg/serverkey.asc) | ` ` |
+| `passbolt.config.jwtcert` | The GPG private server key. If set the private key will not be read from [file](secrets/gpg/serverkey_private.asc) | ` ` |
 | `passbolt.config.license.enabled` | Set true if you own a license key. Add the license key in [secrets/pro-license/license](secrets/pro-license/license) | `false` |
 | `passbolt.config.license.key` | The license key. If set the license key will not be read from [file](secrets/pro-license/license). | `false` |
 | `passbolt.config.plugins.exportenabled` | Enable export plugin | `true` |
@@ -64,11 +66,53 @@ For more parameters you should have a look at ...
 | `passbolt.config.readinessProbe.periodSeconds` | periodSeconds for readinessProbe | `10` |
 | `passbolt.config.readinessProbe.initialDelaySeconds` | initialDelaySeconds for readinessProbe | `60` |
 | `passbolt.config.readinessProbe.timeoutSeconds` | timeoutSeconds for readinessProbe | `10` |
+### Usage
 
+ 1. Create custom values.yaml, probably values.custom.yaml
+ 2. Create gpg and jwt keys
+ 3. Execute: 
+    ```
+    helm install \
+      -f values.custom.yaml \
+      --set-file passbolt.config.serverkey=./gpg/serverkey.asc \
+      --set-file passbolt.config.serverkey_private=./gpg/serverkey_private.asc \
+      --set-file passbolt.config.jwtkey=./jwt/jwt.key \
+      --set-file passbolt.config.jwtcert=./jwt/jwt.pem \
+      passbolt ../passbolt-helm/
+    ```
 
+### Example values.custom.yaml
+```
+ingress:
+  host: "passbolt.example.com"
+  tls:
+    secretName: tls-passbolt-example-com
+    
+passbolt:
+  config:
+    gpgServerKeyFingerprint: ABC123ABC123ABC123ABC123ABC123ABC12
+    registration: true
+    email:
+      enabled: false
+      from: sender@example.com
+      host: mailserver.com
+      port: 587
+      tls: true
+      timeout: 30
+      username: username
+      password: password
+    
+mariadb:
+  db:
+    name: passbolt
+    user: passbolt
+    password: password
+```    
 ### Database
 | Parameter | Description | Default |
 | - | - | - |
+| `mariadb.enabled` | Can be used to false to define an existing external database | `true` |
+| `mariadb.db.host` | Name of the passbolt database | `passbolt` |
 | `mariadb.db.name` | Name of the passbolt database | `passbolt` |
 | `mariadb.db.user` | Username of the passbolt user | `passbolt` |
 | `mariadb.db.password` | Passwort for the passbold database user | `passbolt` |

--- a/requirements.lock
+++ b/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 7.7.2
-digest: sha256:57deb097b06e6606021263743d78f1f4b5df39173b3d1945f9f61d462ad260be
-generated: "2020-08-05T17:20:53.869041+02:00"
+digest: sha256:71afa498fad2963cd961ee928fb308aca36a46fe7311024ab79ed33835c849a5
+generated: "2022-02-13T17:51:12.0891486+01:00"

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
   - name: mariadb
     version: 7.7.2
     repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled

--- a/secrets/jwt/jwt.key
+++ b/secrets/jwt/jwt.key
@@ -1,0 +1,1 @@
+this is a dummy file

--- a/secrets/jwt/jwt.pem
+++ b/secrets/jwt/jwt.pem
@@ -1,0 +1,1 @@
+this is a dummy file

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -99,6 +103,10 @@ spec:
             - name: gpg
               mountPath: /etc/passbolt/gpg
               readOnly: true
+           # - name: passbolt-php-ini-config
+           #   mountPath: /etc/php/7.4/fpm/conf.d/passbolt.ini
+           #   subPath: passbolt.ini
+           #   readOnly: true
             - name: jwt
               mountPath: /etc/passbolt/jwt
               readOnly: true
@@ -134,6 +142,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "passbolt-helm.fullname" . }}-data
         {{- end }}
+        - name: passbolt-php-ini-config
+          configMap:
+            name: {{ template "passbolt-helm.fullname" . }}-phpini
         - name: gpg
           secret:
             secretName: {{ template "passbolt-helm.fullname" . }}-gpg

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,15 +34,24 @@ spec:
           env:
           - name: APP_FULL_BASE_URL
             value: https://{{ .Values.ingress.host }}
+          {{- if .Values.mariadb.enabled }}
           - name: DATASOURCES_DEFAULT_HOST
             value: {{ .Release.Name }}-mariadb
+          {{- else }}
+          - name: DATASOURCES_DEFAULT_HOST
+            value: {{ .Values.mariadb.db.host }}
+          {{- end }}
           - name: DATASOURCES_DEFAULT_USERNAME
             value: {{ .Values.mariadb.db.user }}
           - name: DATASOURCES_DEFAULT_PASSWORD
+          {{- if .Values.mariadb.enabled }}
             valueFrom:
               secretKeyRef:
                 name: {{ .Release.Name }}-mariadb
                 key: mariadb-password
+          {{- else }}
+            value: {{ .Values.mariadb.db.password }}          
+          {{- end }}      
           - name: DATASOURCES_DEFAULT_DATABASE
             value: {{ .Values.mariadb.db.name }}
           {{- if .Values.passbolt.config.email.enabled }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -90,6 +90,9 @@ spec:
             - name: gpg
               mountPath: /etc/passbolt/gpg
               readOnly: true
+            - name: jwt
+              mountPath: /etc/passbolt/jwt
+              readOnly: true
           {{- if .Values.passbolt.config.license.enabled }}
             - name: license
               mountPath: /etc/passbolt/license
@@ -125,6 +128,9 @@ spec:
         - name: gpg
           secret:
             secretName: {{ template "passbolt-helm.fullname" . }}-gpg
+        - name: jwt
+          secret:
+            secretName: {{ template "passbolt-helm.fullname" . }}-jwt
         {{- if .Values.passbolt.config.license.enabled }}
         - name: license
           secret:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -25,11 +27,25 @@ spec:
     http:
       paths:
       - path: /
+        {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: Prefix
+        {{- end }}
         backend:
-          serviceName: {{ template "passbolt-helm.fullname" . }}
+        {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ template "passbolt-helm.fullname" . }}
+            port:
+            {{- if .Values.ingress.tls.enabled }}
+              number: {{ .port | default 443 }}
+            {{- else }}
+              number: {{ .port | default 80 }}
+            {{- end }}
+        {{- else }}
+          serviceName:  {{ template "passbolt-helm.fullname" . }}
           {{- if .Values.ingress.tls.enabled }}
           servicePort: {{ .Values.service.port | default "443" }}
           {{- else }}
           servicePort: {{ .Values.service.port | default "80" }}
           {{- end }}
+        {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -35,17 +35,9 @@ spec:
           service:
             name: {{ template "passbolt-helm.fullname" . }}
             port:
-            {{- if .Values.ingress.tls.enabled }}
-              number: {{ .port | default 443 }}
-            {{- else }}
               number: {{ .port | default 80 }}
-            {{- end }}
         {{- else }}
           serviceName:  {{ template "passbolt-helm.fullname" . }}
-          {{- if .Values.ingress.tls.enabled }}
-          servicePort: {{ .Values.service.port | default "443" }}
-          {{- else }}
           servicePort: {{ .Values.service.port | default "80" }}
-          {{- end }}
         {{- end }}
 {{- end }}

--- a/templates/php-session.yaml
+++ b/templates/php-session.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "passbolt-helm.fullname" . }}-phpini
+data:
+  passbolt.ini: |
+    session.gc_maxlifetime={{ .Values.passbolt.config.session.lifetime }}
+    {{- if .Values.passbolt.config.session.redis.enabled }}
+    session.save_handler = redis
+    session.save_path = "tcp://{{ .Values.passbolt.config.session.redis.service }}:6379"    
+    {{- end }}

--- a/templates/secret-jwt.yaml
+++ b/templates/secret-jwt.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "passbolt-helm.fullname" . }}-jwt
+  labels:
+{{ include "passbolt-helm.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+data:
+  "jwt.asc": {{ if .Values.passbolt.config.jwtkey }}{{ .Values.passbolt.config.jwtkey | b64enc | quote }}{{ else }}{{ .Files.Get "secrets/jwt/jwt.asc" | b64enc | quote }}{{ end }}
+  "jwt.pem": {{ if .Values.passbolt.config.jwtcert }}{{ .Values.passbolt.config.jwtcert | b64enc | quote }}{{ else }}{{ .Files.Get "secrets/jwt/jwt.pem" | b64enc | quote }}{{ end }}

--- a/templates/secret-jwt.yaml
+++ b/templates/secret-jwt.yaml
@@ -8,5 +8,5 @@ metadata:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
-  "jwt.asc": {{ if .Values.passbolt.config.jwtkey }}{{ .Values.passbolt.config.jwtkey | b64enc | quote }}{{ else }}{{ .Files.Get "secrets/jwt/jwt.asc" | b64enc | quote }}{{ end }}
+  "jwt.asc": {{ if .Values.passbolt.config.jwtkey }}{{ .Values.passbolt.config.jwtkey | b64enc | quote }}{{ else }}{{ .Files.Get "secrets/jwt/jwt.key" | b64enc | quote }}{{ end }}
   "jwt.pem": {{ if .Values.passbolt.config.jwtcert }}{{ .Values.passbolt.config.jwtcert | b64enc | quote }}{{ else }}{{ .Files.Get "secrets/jwt/jwt.pem" | b64enc | quote }}{{ end }}

--- a/templates/secret-jwt.yaml
+++ b/templates/secret-jwt.yaml
@@ -8,5 +8,5 @@ metadata:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
-  "jwt.asc": {{ if .Values.passbolt.config.jwtkey }}{{ .Values.passbolt.config.jwtkey | b64enc | quote }}{{ else }}{{ .Files.Get "secrets/jwt/jwt.key" | b64enc | quote }}{{ end }}
+  "jwt.key": {{ if .Values.passbolt.config.jwtkey }}{{ .Values.passbolt.config.jwtkey | b64enc | quote }}{{ else }}{{ .Files.Get "secrets/jwt/jwt.key" | b64enc | quote }}{{ end }}
   "jwt.pem": {{ if .Values.passbolt.config.jwtcert }}{{ .Values.passbolt.config.jwtcert | b64enc | quote }}{{ else }}{{ .Files.Get "secrets/jwt/jwt.pem" | b64enc | quote }}{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,7 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+topologySpreadConstraints: []
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -32,6 +33,13 @@ passbolt:
   config:
     debug: false
     registration: false
+    session:
+      # How many seconds a login is done
+      lifetime: 3600
+      redis:
+        enabled: false
+        service: redis
+    # Generate with https://pwgen.io and 32 chars
     salt: "your salt"
     gpgServerKeyFingerprint: "your gpg server key fingerprint"
     # serverkey_private:

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,8 @@ passbolt:
     gpgServerKeyFingerprint: "your gpg server key fingerprint"
     # serverkey_private:
     # serverkey:
+    # jwtkey:
+    # jwtcert:
     license:
       enabled: false
       # key:
@@ -70,6 +72,7 @@ securityContext: {}
 
 # Database (dependency:mariadb)
 mariadb:
+  enabled: true
   replication:
     enabled: false
   db:

--- a/values.yaml
+++ b/values.yaml
@@ -76,6 +76,9 @@ mariadb:
   replication:
     enabled: false
   db:
+    # define external host, when mariadb is disabled
+    host: internal
+
     name: passbolt
     user: passbolt
     password: passbolt
@@ -95,7 +98,7 @@ ingress:
   host: "passbolt.yourdomain.com"
   tls:
     enabled: false
-  #  secretName: chart-example-tls
+#    secretName: chart-example-tls
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
We add some extra topics into this helm chart, because it don't exactly match our requirements
- At first we make mariadb optional, because we run a galera cluster on kubernetes and don't need an extra database pod.
- We add compatiblity to Kubernetes > 1.20, where Ingress is part of networking.k8s.io/v1
- We added php session settings to extend auto logout. This is work in progress, because we normally would also use redis session storage, which passbolt Docker image cannot use
- We add jwt keys
- At least we adjust README a little bit to give an usage example

This is marked as Draft, because we would like to make it possible to use > 1 replica for higher availablity. But this is prevented by PHP Sessions at the moment.